### PR TITLE
fix: Solve compatibility issues with Singularity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN apt-get update \
 # Copy wipp-pyramid-plugin JAR
 COPY target/wipp-pyramid-plugin*.jar ${EXEC_DIR}/wipp-pyramid-plugin.jar
 
-# Set working directory
-WORKDIR ${EXEC_DIR}
+# Move executable from /tmp folder to allow compatibility with Singularity
+RUN mv /tmp/commandLineCli /opt/executables/commandLineCli
 
 # Default command. Additional arguments are provided through the command line
-ENTRYPOINT ["/usr/bin/java", "-jar", "wipp-pyramid-plugin.jar"]
+ENTRYPOINT ["/usr/bin/java", "-jar", "/opt/executables/wipp-pyramid-plugin.jar"]

--- a/README.md
+++ b/README.md
@@ -30,3 +30,11 @@ docker run \
  ```   
 
 
+## Build container
+
+Prerequisites: `java`, `mvn`
+
+```shell
+mvn package
+docker build . -t wipp-pyramid-plugin
+ ```   

--- a/src/main/java/gov/nist/itl/ssd/wipp/pyramidplugin/PyramidBuilding.java
+++ b/src/main/java/gov/nist/itl/ssd/wipp/pyramidplugin/PyramidBuilding.java
@@ -32,7 +32,7 @@ public class PyramidBuilding {
 	private static final String STITCHING_VECTOR_FILENAME_SUFFIX = ".txt";
 	
 	// Pyramid building options
-	private static final String PYRAMID_BUILDING_COMMAND = "/tmp/commandLineCli";
+	private static final String PYRAMID_BUILDING_COMMAND = "/opt/executables/commandLineCli";
 	private static final String PYRAMID_BUILDING_INPUT_IMAGES_OPTION = "--images";
 	private static final String PYRAMID_BUILDING_INPUT_SV_OPTION = "--vector";
 	private static final String PYRAMID_BUILDING_OUTPUT_DIR = "--output";


### PR DESCRIPTION
I've been testing WIPP plugins in [Singularity](https://sylabs.io/singularity/) container runtime which is often used on HPC clusters instead of Docker. Singularity uses `/tmp` for its [own purposes](https://sylabs.io/guides/3.5/user-guide/build_env.html#temporary-folders), so I propose moving executable from `/tmp` to '/home'.